### PR TITLE
Allow component to re-render when receiving props

### DIFF
--- a/src/DualListBox/index.jsx
+++ b/src/DualListBox/index.jsx
@@ -21,12 +21,19 @@ const defaultProps = {
 };
 
 class DualListBox extends Component {
-  constructor(props) {
-    super(props);
+  constructor() {
+    super();
     this.state = {
-      value: props.initialValue || [],
-      options: props.options || [],
+      value: [],
+      options: [],
     };
+  }
+
+  componentWillReceiveProps = (nextProps) => {
+    this.setState({
+      value: nextProps.initialValue || [],
+      options: nextProps.options || [],
+    });
   }
 
   addSelectedValues = (selectedValues) => {


### PR DESCRIPTION
When initially loading a page with a list box, the component does not update. For example, async request takes time to retrieve data, state is empty on first render, then data is retrieved, state updates, but list box component does not re-render with new data.

```
// console.log() on page reload, data rendering
[]
[]
[Object, Object] // << list-box component doesn't update here and listbox remains empty
```

I noticed that this component's state is initialized with its props, which can work, but think it's better to use a lifecycle method to update state on receiving props; this triggers the state change, updates, and component re-renders effectively. @altayaydemir There are some lint errors with my PR because props are being defined and not used... however, I can't see where to use them after my change! Please review. Thanks!